### PR TITLE
NAS-129799 / 24.10 / Add websocat binary

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+truenas-binaries (2024.07.16-1) unstable; urgency=medium
+
+  * Add websocat-1.13.0
+
+ -- Logan Cary <dev@ixsystems.com>  Tue, 16 Jul 2024 13:35:00 -0500
+
 truenas-binaries (2024.04.29-1) unstable; urgency=medium
 
   * Add ChelsioUwire-3.19.0.1


### PR DESCRIPTION
The `websocat.x86_64-unknown-linux-musl` binary being added was pulled from https://github.com/vi/websocat/releases/tag/v1.13.0.

We are adding this as a vendor specification, and it will be used to run a service exclusively on select vendor installations. See this [PR](https://github.com/truenas/middleware/pull/14009) for its exact usage.